### PR TITLE
removing query logs

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -109,6 +109,9 @@ logging {
     category default{
         main_log;
     };
+    category security { 
+        null; 
+    };
     category lame-servers {
         null;
     };


### PR DESCRIPTION
We're getting a lot of denied query logs on the nameservers, this silences them. We're already getting nameserver stats through packetbeat.

I'll open another PR to update the commit hash in the Puppetfile once this is merged.